### PR TITLE
Fix for rails3.1: DEPRECATION WARNING: class_inheritable_attribute is de...

### DIFF
--- a/app/models/pfeeds/user_updated_attribute.rb
+++ b/app/models/pfeeds/user_updated_attribute.rb
@@ -1,4 +1,4 @@
-class Pfeeds::UserUpdatedAttribute < PfeedItem
+class UserUpdatedAttribute < PfeedItem
   
   def pack_data(method_name,method_name_in_past_tense,returned_result,*args_supplied_to_method,&block_supplied_to_method) 
      super

--- a/lib/pfeed.rb
+++ b/lib/pfeed.rb
@@ -1,5 +1,4 @@
 #snippet: https://gist.github.com/89e92409ca9016d2d919
-
 module ParolkarInnovationLab
   module SocialNet
     def self.included(base)
@@ -17,12 +16,12 @@ module ParolkarInnovationLab
         include ParolkarInnovationLab::SocialNet::InstanceMethods
  
         method_name_array = [*arg_hash[:on]]
-        class_inheritable_hash :pfeed_audience_hash
+        class_attribute :pfeed_audience_hash
         
         method_name_array.each{|method_name| register_pfeed_audience(method_name,[*arg_hash[:for]].compact)  }
 
-        class_inheritable_hash :pfeed_options
-        write_inheritable_hash :pfeed_options, arg_hash.slice(:if,:unless,:identified_by)
+        class_attribute :pfeed_options
+        self.pfeed_options = arg_hash.slice(:if,:unless,:identified_by)
 
         
 
@@ -64,13 +63,12 @@ module ParolkarInnovationLab
       def receives_pfeed
         has_many :pfeed_deliveries , :as => :pfeed_receiver 
         has_many :pfeed_inbox, :class_name => 'PfeedItem', :foreign_key => "pfeed_item_id" , :through => :pfeed_deliveries , :source => :pfeed_item
-
-	write_inheritable_attribute(:is_pfeed_receiver,true)
-        class_inheritable_reader :is_pfeed_receiver
+        class_attribute :is_pfeed_receiver
+        self.is_pfeed_receiver = true
       end
     
       def register_pfeed_audience(method_name,audience_arr)
-         write_inheritable_hash(:pfeed_audience_hash, { method_name.to_sym => audience_arr }) # this does a merge
+         self.pfeed_audience_hash = { method_name.to_sym => audience_arr } # this does a merge
       end
     end
     

--- a/test/lib/pfeed_test.rb
+++ b/test/lib/pfeed_test.rb
@@ -37,7 +37,7 @@ context 'an emitter satisfying an if condition' do
     Emitter.class_eval do
       emits_pfeeds :on => :if_true_ping, :if => :if_true, :for => :itself
     end
-    returning(Emitter.create!(:name => 'bob')) do |e|
+    Emitter.create!(:name => 'bob').tap do |e|
       e.if_true_ping
     end
   end


### PR DESCRIPTION
Making it compatible with Rails 3.1 to suppress the following warnings that clogs the console log.

```
DEPRECATION WARNING: class_inheritable_attribute is deprecated, please use class_attribute method instead. Notice their behavior are slightly different, so refer to class_attribute documentation first. (called from emits_pfeeds at /var/lib/jenkins/jobs/CloudFactory/workspace/vendor/plugins/pfeed/lib/pfeed.rb:20)
DEPRECATION WARNING: class_inheritable_attribute is deprecated, please use class_attribute method instead. Notice their behavior are slightly different, so refer to class_attribute documentation first. (called from emits_pfeeds at /var/lib/jenkins/jobs/CloudFactory/workspace/vendor/plugins/pfeed/lib/pfeed.rb:20)
DEPRECATION WARNING: class_inheritable_attribute is deprecated, please use class_attribute method instead. Notice their behavior are slightly different, so refer to class_attribute documentation first. (called from emits_pfeeds at /var/lib/jenkins/jobs/CloudFactory/workspace/vendor/plugins/pfeed/lib/pfeed.rb:24)
DEPRECATION WARNING: class_inheritable_attribute is deprecated, please use class_attribute method instead. Notice their behavior are slightly different, so refer to class_attribute documentation first. (called from emits_pfeeds at /var/lib/jenkins/jobs/CloudFactory/workspace/vendor/plugins/pfeed/lib/pfeed.rb:24)
DEPRECATION WARNING: class_inheritable_attribute is deprecated, please use class_attribute method instead. Notice their behavior are slightly different, so refer to class_attribute documentation first. (called from receives_pfeed at /var/lib/jenkins/jobs/CloudFactory/workspace/vendor/plugins/pfeed/lib/pfeed.rb:69)
```
